### PR TITLE
feat(token):优化摘要策略下的消息本体token计算逻辑 

### DIFF
--- a/AgentX/src/main/java/org/xhy/application/conversation/service/ConversationAppService.java
+++ b/AgentX/src/main/java/org/xhy/application/conversation/service/ConversationAppService.java
@@ -404,10 +404,7 @@ public class ConversationAppService {
     private MessageEntity summaryMessageToEntity(TokenMessage tokenMessage, String sessionId) {
         MessageEntity messageEntity = new MessageEntity();
         BeanUtil.copyProperties(tokenMessage, messageEntity);
-        messageEntity.setId(tokenMessage.getId());
         messageEntity.setRole(Role.fromCode(tokenMessage.getRole()));
-        messageEntity.setCreatedAt(tokenMessage.getCreatedAt());
-        messageEntity.setUpdatedAt(tokenMessage.getCreatedAt());
         messageEntity.setSessionId(sessionId);
         messageEntity.setMessageType(MessageType.TEXT);
         return messageEntity;

--- a/AgentX/src/main/java/org/xhy/domain/conversation/constant/Role.java
+++ b/AgentX/src/main/java/org/xhy/domain/conversation/constant/Role.java
@@ -5,7 +5,9 @@ import org.xhy.infrastructure.exception.BusinessException;
 
 public enum Role {
 
-    USER, SYSTEM, ASSISTANT, SUMMARY;
+    USER, SYSTEM, ASSISTANT,
+    /** 只会存在历史消息表中作为特殊消息存在，而实际发送给大模型的消息时会被转换对应的消息类型：AiMessage */
+    SUMMARY;
 
     public static Role fromCode(String code) {
         for (Role role : values()) {

--- a/AgentX/src/main/java/org/xhy/domain/conversation/constant/Role.java
+++ b/AgentX/src/main/java/org/xhy/domain/conversation/constant/Role.java
@@ -5,7 +5,7 @@ import org.xhy.infrastructure.exception.BusinessException;
 
 public enum Role {
 
-    USER, SYSTEM, ASSISTANT;
+    USER, SYSTEM, ASSISTANT, SUMMARY;
 
     public static Role fromCode(String code) {
         for (Role role : values()) {

--- a/AgentX/src/main/java/org/xhy/domain/conversation/model/MessageEntity.java
+++ b/AgentX/src/main/java/org/xhy/domain/conversation/model/MessageEntity.java
@@ -160,6 +160,10 @@ public class MessageEntity extends BaseEntity {
         return this.role == Role.SYSTEM;
     }
 
+    public boolean isSummaryMessage() {
+        return this.role == Role.SUMMARY;
+    }
+
     public List<String> getFileUrls() {
         return fileUrls;
     }

--- a/AgentX/src/main/java/org/xhy/domain/conversation/service/ConversationDomainService.java
+++ b/AgentX/src/main/java/org/xhy/domain/conversation/service/ConversationDomainService.java
@@ -28,7 +28,7 @@ public class ConversationDomainService {
     public List<MessageEntity> getConversationMessages(String sessionId) {
         return messageRepository
                 .selectList(Wrappers.<MessageEntity>lambdaQuery().eq(MessageEntity::getSessionId, sessionId)
-                        .ne(MessageEntity::getRole, Role.SUMMARY.name()).orderByAsc(MessageEntity::getCreatedAt));
+                        .ne(MessageEntity::getRole, Role.SUMMARY).orderByAsc(MessageEntity::getCreatedAt));
     }
 
     public void insertBathMessage(List<MessageEntity> messages) {

--- a/AgentX/src/main/java/org/xhy/domain/conversation/service/ConversationDomainService.java
+++ b/AgentX/src/main/java/org/xhy/domain/conversation/service/ConversationDomainService.java
@@ -4,6 +4,7 @@ import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.xhy.domain.conversation.constant.Role;
 import org.xhy.domain.conversation.model.MessageEntity;
 import org.xhy.domain.conversation.repository.MessageRepository;
 
@@ -25,8 +26,9 @@ public class ConversationDomainService {
      * @param sessionId 会话id
      * @return 消息列表 */
     public List<MessageEntity> getConversationMessages(String sessionId) {
-        return messageRepository.selectList(Wrappers.<MessageEntity>lambdaQuery()
-                .eq(MessageEntity::getSessionId, sessionId).orderByAsc(MessageEntity::getCreatedAt));
+        return messageRepository
+                .selectList(Wrappers.<MessageEntity>lambdaQuery().eq(MessageEntity::getSessionId, sessionId)
+                        .ne(MessageEntity::getRole, Role.SUMMARY.name()).orderByAsc(MessageEntity::getCreatedAt));
     }
 
     public void insertBathMessage(List<MessageEntity> messages) {

--- a/AgentX/src/main/java/org/xhy/domain/token/service/impl/SlidingWindowTokenOverflowStrategy.java
+++ b/AgentX/src/main/java/org/xhy/domain/token/service/impl/SlidingWindowTokenOverflowStrategy.java
@@ -105,7 +105,7 @@ public class SlidingWindowTokenOverflowStrategy implements TokenOverflowStrategy
 
     /** 计算消息列表的总token数 */
     private int calculateTotalTokens(List<TokenMessage> messages) {
-        return messages.stream().mapToInt(m -> m.getTokenCount() != null ? m.getTokenCount() : 0).sum();
+        return messages.stream().mapToInt(m -> m.getBodyTokenCount() != null ? m.getBodyTokenCount() : 0).sum();
     }
 
     /** 获取配置的最大Token数，如果未配置则使用默认值

--- a/AgentX/src/test/java/org/xhy/application/conversation/service/ConversationAppServiceTest.java
+++ b/AgentX/src/test/java/org/xhy/application/conversation/service/ConversationAppServiceTest.java
@@ -14,6 +14,11 @@ import org.xhy.infrastructure.llm.protocol.enums.ProviderProtocol;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Scanner;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 //@SpringBootTest
@@ -23,20 +28,75 @@ public class ConversationAppServiceTest {
     // private ConversationAppService conversationAppService;
 
     public static void main(String[] args) {
-        List<String> messageTextList = List.of("HashMap在JVM中的内存布局如何"); // 11
+        // testSameMessageBodyTokenWithDiffHistory();
+        testSingleMessageBodyTokenWithAgentPrompt();
+    }
+
+    private static void testSingleMessageBodyTokenWithAgentPrompt() {
+        List<String> messageTextList = List.of("跟他差不多水平的歌手有谁");
         String systemMessageText = "你是一个有用的AI助手。"; // token: 8
         String summaryPrefix = "以下是用户历史消息的摘要，请仅作为参考，用户没有提起则不要回答摘要中的内容：\\n"; // token: 26
-        ProviderConfig providerConfig = new ProviderConfig("", "https://api.siliconflow.cn/v1",
+        Scanner scanner = new Scanner(System.in);
+        System.out.print("请输入API密钥: ");
+        String apiKey = scanner.nextLine();
+        scanner.close();
+        ProviderConfig providerConfig = new ProviderConfig(apiKey, "https://api.siliconflow.cn/v1",
                 "deepseek-ai/DeepSeek-V3", ProviderProtocol.OPENAI);
         // 使用当前服务商调用大模型
         ChatModel chatLanguageModel = LLMProviderService.getStrand(providerConfig.getProtocol(), providerConfig);
         SystemMessage systemMessage = new SystemMessage(systemMessageText);
+        sendMessage("singleMessage", messageTextList, systemMessage, chatLanguageModel);
+    }
+
+    /** 可以看到消息本体token在历史消息中算得的本体token略小于没有历史消息单独计算的本体token，但是误差不大，作为token策略来说，可以忽略
+     * @return 空 */
+    private static void testSameMessageBodyTokenWithDiffHistory() {
+        Scanner scanner = new Scanner(System.in);
+        System.out.print("请输入API密钥: ");
+        String apiKey = scanner.nextLine();
+        scanner.close();
+        String sameMessageText = "跟他差不多水平的歌手有谁"; // singleWithAgentPromptToken: 15
+        List<String> messageTextList1 = List.of("我是真的真的真的真的喜欢腻啊，坤坤", sameMessageText); // diff: 20 total: 28
+        List<String> messageTextList2 = List.of("时代少年团，我们喜欢腻，我们稀饭倪啊，我们喜欢泥", sameMessageText); // diff: 26 total: 34
+        List<List<String>> messages4Testing = new ArrayList<>();
+        messages4Testing.add(messageTextList1);
+        messages4Testing.add(messageTextList2);
+        String systemMessageText = "你是一个有用的AI助手。"; // token: 8
+        ProviderConfig providerConfig = new ProviderConfig(apiKey, "https://api.siliconflow.cn/v1",
+                "deepseek-ai/DeepSeek-V3", ProviderProtocol.OPENAI);
+        // 使用当前服务商调用大模型
+        ChatModel chatLanguageModel = LLMProviderService.getStrand(providerConfig.getProtocol(), providerConfig);
+        SystemMessage systemMessage = new SystemMessage(systemMessageText);
+        ExecutorService executorService = Executors.newFixedThreadPool(messages4Testing.size());
+        for (int i = 0; i < messages4Testing.size(); i++) {
+            List<String> messageTextList = messages4Testing.get(i);
+            int finalI = i;
+            executorService.submit(() -> {
+                sendMessage(finalI + "", messageTextList, systemMessage, chatLanguageModel);
+            });
+        }
+        executorService.shutdown();
+        try {
+            // 等待所有任务执行完成
+            if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+                // 如果超时则强制关闭
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            // 如果等待过程中被中断，则强制关闭
+            executorService.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void sendMessage(String logName, List<String> messageTextList1, SystemMessage systemMessage,
+            ChatModel chatLanguageModel) {
         List<ChatMessage> chatMessages = new ArrayList<>();
-        for (String messageText : messageTextList) {
+        for (String messageText : messageTextList1) {
             chatMessages.add(new UserMessage(messageText));
         }
         chatMessages.add(systemMessage);
         ChatResponse chatResponse = chatLanguageModel.chat(chatMessages);
-        System.out.println("input_token_count: " + chatResponse.tokenUsage().inputTokenCount());
+        System.out.println(logName + " input_token_count: " + chatResponse.tokenUsage().inputTokenCount());
     }
 }

--- a/AgentX/src/test/java/org/xhy/application/conversation/service/ConversationAppServiceTest.java
+++ b/AgentX/src/test/java/org/xhy/application/conversation/service/ConversationAppServiceTest.java
@@ -26,8 +26,8 @@ public class ConversationAppServiceTest {
         List<String> messageTextList = List.of("HashMap在JVM中的内存布局如何"); // 11
         String systemMessageText = "你是一个有用的AI助手。"; // token: 8
         String summaryPrefix = "以下是用户历史消息的摘要，请仅作为参考，用户没有提起则不要回答摘要中的内容：\\n"; // token: 26
-        ProviderConfig providerConfig = new ProviderConfig("",
-                "https://api.siliconflow.cn/v1", "deepseek-ai/DeepSeek-V3", ProviderProtocol.OPENAI);
+        ProviderConfig providerConfig = new ProviderConfig("", "https://api.siliconflow.cn/v1",
+                "deepseek-ai/DeepSeek-V3", ProviderProtocol.OPENAI);
         // 使用当前服务商调用大模型
         ChatModel chatLanguageModel = LLMProviderService.getStrand(providerConfig.getProtocol(), providerConfig);
         SystemMessage systemMessage = new SystemMessage(systemMessageText);

--- a/AgentX/src/test/java/org/xhy/application/conversation/service/ConversationAppServiceTest.java
+++ b/AgentX/src/test/java/org/xhy/application/conversation/service/ConversationAppServiceTest.java
@@ -1,0 +1,42 @@
+package org.xhy.application.conversation.service;
+
+import dev.langchain4j.data.message.*;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xhy.domain.conversation.constant.Role;
+import org.xhy.domain.conversation.model.MessageEntity;
+import org.xhy.infrastructure.llm.LLMProviderService;
+import org.xhy.infrastructure.llm.config.ProviderConfig;
+import org.xhy.infrastructure.llm.protocol.enums.ProviderProtocol;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+//@SpringBootTest
+public class ConversationAppServiceTest {
+
+    // @Autowired
+    // private ConversationAppService conversationAppService;
+
+    public static void main(String[] args) {
+        List<String> messageTextList = List.of("HashMap在JVM中的内存布局如何"); // 11
+        String systemMessageText = "你是一个有用的AI助手。"; // token: 8
+        String summaryPrefix = "以下是用户历史消息的摘要，请仅作为参考，用户没有提起则不要回答摘要中的内容：\\n"; // token: 26
+        ProviderConfig providerConfig = new ProviderConfig("",
+                "https://api.siliconflow.cn/v1", "deepseek-ai/DeepSeek-V3", ProviderProtocol.OPENAI);
+        // 使用当前服务商调用大模型
+        ChatModel chatLanguageModel = LLMProviderService.getStrand(providerConfig.getProtocol(), providerConfig);
+        SystemMessage systemMessage = new SystemMessage(systemMessageText);
+        List<ChatMessage> chatMessages = new ArrayList<>();
+        for (String messageText : messageTextList) {
+            chatMessages.add(new UserMessage(messageText));
+        }
+        chatMessages.add(systemMessage);
+        ChatResponse chatResponse = chatLanguageModel.chat(chatMessages);
+        System.out.println("input_token_count: " + chatResponse.tokenUsage().inputTokenCount());
+    }
+}


### PR DESCRIPTION
Close #114 
触发摘要策略后，生成摘要消息记录并保存到数据库中，Role为 SUMMARY。
每触发一次都会拼接老摘要生成新的摘要消息记录，然后插入历史消息中，在计算消息本体token时减去，保证消息本体token的准确。此提交也优化了摘要前缀提示词的设计，只有第一次生成摘要时摘要消息会有前缀，并通过让大模型返回的摘要带上前缀的方式算上了前缀的token值，进一步保证消息本体token的准确