### PR TITLE
chore(01_init.sql): 补充文档分片表建表脚本

### DIFF
--- a/docs/sql/01_init.sql
+++ b/docs/sql/01_init.sql
@@ -1209,3 +1209,14 @@ comment on column public.agent_execution_summary.tool_call_count is '工具调�
 comment on column public.agent_execution_summary.total_cost is '总成本费用';
 comment on column public.agent_execution_summary.execution_success is '执行是否成功';
 
+create table public.vector_store (
+                                     embedding_id uuid primary key not null,
+                                     embedding vector(1024),
+                                     text text,
+                                     metadata json
+);
+comment on column public.vector_store is '文档分片表 (用于向量存储)';
+comment on column public.vector_store.embedding_id is '向量ID';
+comment on column public.vector_store.embedding is '向量数据';
+comment on column public.vector_store.text is '分片文本 (进行向量化的文本片段)';
+comment on column public.vector_store.metadata is '分片元数据';


### PR DESCRIPTION
文件修改：docs/sql/01_init.sql

change:

查看 src/main/resources/db/rag_tables.sql 后，得知初始化的建表脚本漏了 public.vector_store，因此补充。

<img width="782" height="360" alt="image" src="https://github.com/user-attachments/assets/c389c58f-d7d7-47e6-bec4-da9f4a887f12" />


<img width="827" height="436" alt="image" src="https://github.com/user-attachments/assets/07f907de-ef60-4f60-b5a0-0ae77cb16a9b" />
